### PR TITLE
Make comment Input box a Textarea so that more of the text is visible

### DIFF
--- a/pages/a/[formId]/submissions/[submissionId].tsx
+++ b/pages/a/[formId]/submissions/[submissionId].tsx
@@ -12,7 +12,7 @@ import {
   Heading,
   HStack,
   IconButton,
-  Input,
+  Textarea,
   LightMode,
   Modal,
   ModalBody,
@@ -221,11 +221,12 @@ const CommentModal = ({ isOpen, onClose, onSubmit }: CommentModalProps) => {
           <form id="comment" onSubmit={handleSubmit}>
             <FormControl>
               <FormLabel>Comment</FormLabel>
-              <Input
+              <Textarea
                 name="comment"
                 placeholder="Enter comment..."
                 value={comment}
                 onChange={(e) => setComment(e.target.value)}
+                style="height: 200px;"
               />
               <FormHelperText>This comment will be sent to the submitter.</FormHelperText>
             </FormControl>


### PR DESCRIPTION
THIS PR IS UNTESTED, although I did test the attributes using inspect element on the actual website

This PR changes the comment Input element in the submission page to a Textarea element so that more of the text you type for the comment is visible.