### PR TITLE
feat: show prior rejection reasons on submission detail page

### DIFF
--- a/helpers/db.ts
+++ b/helpers/db.ts
@@ -185,6 +185,24 @@ export const fetchSubmissions = async <T = any>(
   return cursor;
 };
 
+export const fetchUserRejectedSubmissions = async (
+  formId: string,
+  userId: string,
+  excludeSubmissionId?: string
+) => {
+  const db = await dbPromise;
+  const collection = db.collection("submission");
+  const query: any = {
+    form_id: formId,
+    user_id: Long.fromString(userId),
+    status: SubmissionStatus.REJECTED,
+    ...(excludeSubmissionId
+      ? { _id: { $ne: ObjectId.createFromHexString(excludeSubmissionId) } }
+      : {}),
+  };
+  return collection.find<Submission>(query).sort({ _id: -1 }).toArray();
+};
+
 export const createSubmission = async <T = any>(submission: Omit<Submission<T>, "_id">) => {
   const db = await dbPromise;
   const collection = db.collection("submission");

--- a/pages/a/[formId]/submissions/[submissionId].tsx
+++ b/pages/a/[formId]/submissions/[submissionId].tsx
@@ -26,6 +26,7 @@ import {
   PopoverTrigger,
   Portal,
   Stack,
+  Tag,
   Text,
   Textarea,
   chakra,
@@ -37,7 +38,7 @@ import { HiCheck, HiFlag, HiX } from "react-icons/hi";
 
 import ErrorAlert from "~components/formium/ErrorAlert";
 import SubmissionsLayout from "~components/layouts/SubmissionsLayout";
-import { fetchSubmission, fetchSubmissions } from "~helpers/db";
+import { fetchSubmission, fetchSubmissions, fetchUserRejectedSubmissions } from "~helpers/db";
 import { formium } from "~helpers/formium";
 import { permittedToViewForm } from "~helpers/permissions";
 import { AuthMode, withServerSideSession } from "~helpers/session";
@@ -211,12 +212,19 @@ const SubmissionHeader = ({ submission, onSetStatus }: SubmissionHeaderProps) =>
   );
 };
 
+type PriorRejection = {
+  _id: string;
+  comment: string | null;
+  reviewer_id: string | null;
+};
+
 type SubmissionContentProps = {
   form: Form;
   submission: SerializableSubmission;
+  priorRejections: PriorRejection[];
 };
 
-const SubmissionContent = ({ form, submission }: SubmissionContentProps) => {
+const SubmissionContent = ({ form, submission, priorRejections }: SubmissionContentProps) => {
   const fieldNames = Object.values(form.schema?.fields ?? {}).reduce(
     (acc, val) => acc.set(val.slug, val.title),
     new Map<string, string | undefined>()
@@ -256,6 +264,26 @@ const SubmissionContent = ({ form, submission }: SubmissionContentProps) => {
           <Text>{submission.data[x]}</Text>
         </Stack>
       ))}
+
+      {priorRejections.length > 0 && (
+        <>
+          <Divider />
+          <Heading size="sm">Prior Rejections</Heading>
+          {priorRejections.map((r) => (
+            <Stack key={r._id} shadow={shadow} bg={bg} rounded="md" p="4" alignItems="flex-start">
+              <HStack>
+                <Tag colorScheme="red" size="sm">Rejected</Tag>
+                {r.reviewer_id && (
+                  <Text fontSize="sm" color="gray.500">
+                    by {r.reviewer_id}
+                  </Text>
+                )}
+              </HStack>
+              <Text>{r.comment ?? "No comment provided."}</Text>
+            </Stack>
+          ))}
+        </>
+      )}
     </Stack>
   );
 };
@@ -317,9 +345,10 @@ type SubmissionPageProps = {
   form: Form;
   submissions: SerializableSubmission[];
   submission: SerializableSubmission;
+  priorRejections: PriorRejection[];
 };
 
-const SubmissionPage = ({ user, form, submissions, submission }: SubmissionPageProps) => {
+const SubmissionPage = ({ user, form, submissions, submission, priorRejections }: SubmissionPageProps) => {
   const [subs, setSubs] = useState(submissions);
   const [sub, setSub] = useState(submission);
   const [statusWithComment, setStatusWithComment] = useState<SubmissionStatus | undefined>();
@@ -371,7 +400,7 @@ const SubmissionPage = ({ user, form, submissions, submission }: SubmissionPageP
           <SubmissionHeader submission={sub} onSetStatus={handleSetStatus} />
         </Box>
         <Box flex="1" overflow="auto" p="6" zIndex={0}>
-          <SubmissionContent key={form.id} form={form} submission={sub} />
+          <SubmissionContent key={form.id} form={form} submission={sub} priorRejections={priorRejections} />
         </Box>
       </Flex>
       <CommentModal
@@ -423,6 +452,17 @@ export const getServerSideProps = withServerSideSession<SubmissionPageProps, Sub
 
     if (!submission) return { notFound: true };
 
+    const _priorRejections = await fetchUserRejectedSubmissions(
+      form.slug,
+      submission.user_id.toString(),
+      submission._id.toString()
+    );
+    const priorRejections: PriorRejection[] = _priorRejections.map((s) => ({
+      _id: s._id.toString(),
+      comment: s.comment ?? null,
+      reviewer_id: s.reviewer_id?.toString() ?? null,
+    }));
+
     return {
       props: {
         id: formId,
@@ -430,6 +470,7 @@ export const getServerSideProps = withServerSideSession<SubmissionPageProps, Sub
         user,
         submissions: submissions.map(makeSerializable),
         submission: makeSerializable(submission),
+        priorRejections,
       },
     };
   },


### PR DESCRIPTION
## Summary

When reviewing a submission, reviewers can now see prior rejection reasons from the same user's previous submissions on the same form. This adds a "Prior Rejections" section below the form data, showing each prior rejected submission's comment and reviewer ID.

**Changes:**
- Added `fetchUserRejectedSubmissions` to `helpers/db.ts` — queries all rejected submissions for a given user/form, excluding the current submission
- Added a "Prior Rejections" UI section in the submission detail view (`[submissionId].tsx`) that renders below the form fields when prior rejections exist

## Review & Testing Checklist for Human

- [ ] **Reviewer ID display**: Prior rejections show the raw reviewer Discord ID (e.g. `by 716390832034414685`), not a resolved username. Verify this is acceptable or if it should resolve to a username/tag.
- [ ] **Query has no limit**: `fetchUserRejectedSubmissions` returns all matching rejected submissions with no cap. Consider whether a limit is needed for users with many prior rejections.
- [ ] **Current submission's comment not shown**: Only *other* submissions' rejection reasons are displayed. If the current submission itself was rejected and later re-reviewed, its own comment is not surfaced separately. Verify this matches intent.
- [ ] **Test end-to-end**: Find a user with multiple submissions on the same form where at least one was rejected with a comment. Verify the "Prior Rejections" section appears correctly on their other submissions.

### Notes
- The query fetches all historical rejected submissions (no time filter like the 6-month `onlyRecent` used elsewhere). This is intentional to surface full rejection history.
- The `Portal` import in the original file was unused and remains so — not touched by this PR.

Link to Devin session: https://app.devin.ai/sessions/1c0b394f3ea84d50bc846b5f87564beb
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/forms.poketwo.net/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
