### PR TITLE
feat: add My Submissions page with grouped forms, prior rejections, and answer viewing

### DIFF
--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -27,7 +27,15 @@ import {
 import { useRouter } from "next/dist/client/router";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
-import { HiClipboardList, HiHome, HiLogout, HiMoon, HiSelector, HiSun } from "react-icons/hi";
+import {
+  HiClipboardList,
+  HiCollection,
+  HiHome,
+  HiLogout,
+  HiMoon,
+  HiSelector,
+  HiSun,
+} from "react-icons/hi";
 
 import { User } from "~helpers/types";
 
@@ -128,6 +136,7 @@ const NavItem = ({ href, subtle = false, icon, label }: NavItemProps) => {
 const Navigation = () => (
   <Stack spacing="1">
     <NavItem href="/dashboard" icon={<HiHome />} label="Home" />
+    <NavItem href="/my-submissions" icon={<HiCollection />} label="My Submissions" />
     <NavItem
       href="/a/moderator-application"
       icon={<HiClipboardList />}

--- a/helpers/db.ts
+++ b/helpers/db.ts
@@ -185,6 +185,13 @@ export const fetchSubmissions = async <T = any>(
   return cursor;
 };
 
+export const fetchUserSubmissions = async <T = any>(userId: string) => {
+  const db = await dbPromise;
+  const collection = db.collection("submission");
+  const query = { user_id: Long.fromString(userId) };
+  return collection.find<Submission<T>>(query).sort({ _id: -1 });
+};
+
 export const createSubmission = async <T = any>(submission: Omit<Submission<T>, "_id">) => {
   const db = await dbPromise;
   const collection = db.collection("submission");

--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -17,7 +17,14 @@ import MainLayout from "~components/layouts/MainLayout";
 import { fetchUserSubmissions } from "~helpers/db";
 import { formium } from "~helpers/formium";
 import { AuthMode, withServerSideSession } from "~helpers/session";
-import { SerializableSubmission, SubmissionStatus, User, makeSerializable } from "~helpers/types";
+import { SubmissionStatus, User, makeSerializable } from "~helpers/types";
+
+type UserSubmission = {
+  _id: string;
+  form_id: string;
+  status: SubmissionStatus | null;
+  comment: string | null;
+};
 
 const FORMS = ["moderator-application", "ban-appeal", "suspension-appeal"];
 
@@ -51,7 +58,7 @@ const getDateFromObjectId = (id: string): string => {
 };
 
 type SubmissionCardProps = {
-  submission: SerializableSubmission;
+  submission: UserSubmission;
 };
 
 const SubmissionCard = ({ submission }: SubmissionCardProps) => {
@@ -80,7 +87,7 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
 };
 
 type PriorRejectionProps = {
-  submission: SerializableSubmission;
+  submission: UserSubmission;
 };
 
 const PriorRejection = ({ submission }: PriorRejectionProps) => {
@@ -102,8 +109,8 @@ const PriorRejection = ({ submission }: PriorRejectionProps) => {
 type FormGroup = {
   formSlug: string;
   formName: string;
-  latest: SerializableSubmission;
-  priorRejections: SerializableSubmission[];
+  latest: UserSubmission;
+  priorRejections: UserSubmission[];
 };
 
 type FormGroupCardProps = {
@@ -164,7 +171,7 @@ const FormGroupCard = ({ group }: FormGroupCardProps) => {
 type MySubmissionsProps = {
   user: User;
   formGroups: FormGroup[];
-  ungroupedSubmissions: SerializableSubmission[];
+  ungroupedSubmissions: UserSubmission[];
 };
 
 const MySubmissions = ({ user, formGroups, ungroupedSubmissions }: MySubmissionsProps) => {
@@ -200,7 +207,12 @@ export const getServerSideProps = withServerSideSession<MySubmissionsProps>(asyn
 
   const _submissions = await fetchUserSubmissions(user.id);
   const submissions = await _submissions.toArray();
-  const serialized = submissions.map(makeSerializable);
+  const serialized = submissions.map(makeSerializable).map(({ _id, form_id, status, comment }) => ({
+    _id,
+    form_id,
+    status,
+    comment,
+  }));
 
   const forms = await Promise.allSettled(FORMS.map((slug) => formium.getFormBySlug(slug)));
   const formNames: { [key: string]: string } = {};
@@ -211,8 +223,8 @@ export const getServerSideProps = withServerSideSession<MySubmissionsProps>(asyn
   });
 
   // Group submissions by form
-  const byForm: { [formId: string]: SerializableSubmission[] } = {};
-  const ungroupedSubmissions: SerializableSubmission[] = [];
+  const byForm: { [formId: string]: UserSubmission[] } = {};
+  const ungroupedSubmissions: UserSubmission[] = [];
 
   for (const sub of serialized) {
     if (FORMS.includes(sub.form_id)) {

--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -1,0 +1,137 @@
+import {
+  Badge,
+  Box,
+  Heading,
+  HStack,
+  Stack,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { Form } from "@formium/types";
+import Link from "next/link";
+
+import MainLayout from "~components/layouts/MainLayout";
+import { fetchUserSubmissions } from "~helpers/db";
+import { formium } from "~helpers/formium";
+import { AuthMode, withServerSideSession } from "~helpers/session";
+import { SerializableSubmission, SubmissionStatus, User, makeSerializable } from "~helpers/types";
+
+const FORMS = ["moderator-application", "ban-appeal", "suspension-appeal"];
+
+const STATUS_LABELS: { [key in SubmissionStatus]: string } = {
+  [SubmissionStatus.UNDER_REVIEW]: "Under Review",
+  [SubmissionStatus.ACCEPTED]: "Accepted",
+  [SubmissionStatus.REJECTED]: "Rejected",
+  [SubmissionStatus.MARKED_ORANGE]: "Under Review",
+  [SubmissionStatus.MARKED_YELLOW]: "Under Review",
+  [SubmissionStatus.MARKED_BLUE]: "Under Review",
+  [SubmissionStatus.MARKED_PURPLE]: "Under Review",
+};
+
+const STATUS_COLORS: { [key in SubmissionStatus]: string } = {
+  [SubmissionStatus.UNDER_REVIEW]: "yellow",
+  [SubmissionStatus.ACCEPTED]: "green",
+  [SubmissionStatus.REJECTED]: "red",
+  [SubmissionStatus.MARKED_ORANGE]: "yellow",
+  [SubmissionStatus.MARKED_YELLOW]: "yellow",
+  [SubmissionStatus.MARKED_BLUE]: "yellow",
+  [SubmissionStatus.MARKED_PURPLE]: "yellow",
+};
+
+const getDateFromObjectId = (id: string): string => {
+  const timestamp = parseInt(id.substring(0, 8), 16) * 1000;
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+type SubmissionCardProps = {
+  submission: SerializableSubmission;
+  formName: string;
+};
+
+const SubmissionCard = ({ submission, formName }: SubmissionCardProps) => {
+  const shadow = useColorModeValue("base", "md");
+  const bg = useColorModeValue("white", "gray.800");
+  const status = submission.status ?? SubmissionStatus.UNDER_REVIEW;
+
+  return (
+    <Stack shadow={shadow} bg={bg} rounded="md" p="4" spacing="3">
+      <HStack justifyContent="space-between" alignItems="flex-start">
+        <Box>
+          <Text fontSize="md" fontWeight="bold">
+            {formName}
+          </Text>
+          <Text fontSize="sm" color="gray.500">
+            {getDateFromObjectId(submission._id)}
+          </Text>
+        </Box>
+        <Badge colorScheme={STATUS_COLORS[status]}>{STATUS_LABELS[status]}</Badge>
+      </HStack>
+      {submission.comment && (
+        <Box borderLeftWidth="2px" borderColor="gray.500" pl="3">
+          <Text fontSize="sm" color="gray.400">
+            Reviewer Comment
+          </Text>
+          <Text fontSize="sm">{submission.comment}</Text>
+        </Box>
+      )}
+    </Stack>
+  );
+};
+
+type MySubmissionsProps = {
+  user: User;
+  submissions: SerializableSubmission[];
+  formNames: { [key: string]: string };
+};
+
+const MySubmissions = ({ user, submissions, formNames }: MySubmissionsProps) => {
+  return (
+    <MainLayout user={user}>
+      <Stack spacing="4" maxW="xl" mx="auto">
+        <Heading mb="2">My Submissions</Heading>
+
+        {submissions.length === 0 ? (
+          <Text color="gray.500">You have not submitted any forms yet.</Text>
+        ) : (
+          submissions.map((submission) => (
+            <SubmissionCard
+              key={submission._id}
+              submission={submission}
+              formName={formNames[submission.form_id] ?? submission.form_id}
+            />
+          ))
+        )}
+      </Stack>
+    </MainLayout>
+  );
+};
+
+export default MySubmissions;
+
+export const getServerSideProps = withServerSideSession<MySubmissionsProps>(async ({ req }) => {
+  const user = req.session.user;
+  if (!user) throw new Error("User not found");
+
+  const _submissions = await fetchUserSubmissions(user.id);
+  const submissions = await _submissions.toArray();
+
+  const forms = await Promise.allSettled(FORMS.map((slug) => formium.getFormBySlug(slug)));
+  const formNames: { [key: string]: string } = {};
+  forms.forEach((result, i) => {
+    if (result.status === "fulfilled") {
+      formNames[FORMS[i]] = result.value.name;
+    }
+  });
+
+  return {
+    props: {
+      user,
+      submissions: submissions.map(makeSerializable),
+      formNames,
+    },
+  };
+}, AuthMode.AUTHENTICATED);

--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -1,14 +1,17 @@
 import {
   Badge,
   Box,
+  Button,
+  Divider,
   Heading,
   HStack,
   Stack,
+  Tag,
   Text,
   useColorModeValue,
 } from "@chakra-ui/react";
-import { Form } from "@formium/types";
 import Link from "next/link";
+import { HiChevronRight } from "react-icons/hi";
 
 import MainLayout from "~components/layouts/MainLayout";
 import { fetchUserSubmissions } from "~helpers/db";
@@ -49,10 +52,9 @@ const getDateFromObjectId = (id: string): string => {
 
 type SubmissionCardProps = {
   submission: SerializableSubmission;
-  formName: string;
 };
 
-const SubmissionCard = ({ submission, formName }: SubmissionCardProps) => {
+const SubmissionCard = ({ submission }: SubmissionCardProps) => {
   const shadow = useColorModeValue("base", "md");
   const bg = useColorModeValue("white", "gray.800");
   const status = submission.status ?? SubmissionStatus.UNDER_REVIEW;
@@ -60,14 +62,9 @@ const SubmissionCard = ({ submission, formName }: SubmissionCardProps) => {
   return (
     <Stack shadow={shadow} bg={bg} rounded="md" p="4" spacing="3">
       <HStack justifyContent="space-between" alignItems="flex-start">
-        <Box>
-          <Text fontSize="md" fontWeight="bold">
-            {formName}
-          </Text>
-          <Text fontSize="sm" color="gray.500">
-            {getDateFromObjectId(submission._id)}
-          </Text>
-        </Box>
+        <Text fontSize="sm" color="gray.500">
+          {getDateFromObjectId(submission._id)}
+        </Text>
         <Badge colorScheme={STATUS_COLORS[status]}>{STATUS_LABELS[status]}</Badge>
       </HStack>
       {submission.comment && (
@@ -82,28 +79,113 @@ const SubmissionCard = ({ submission, formName }: SubmissionCardProps) => {
   );
 };
 
-type MySubmissionsProps = {
-  user: User;
-  submissions: SerializableSubmission[];
-  formNames: { [key: string]: string };
+type PriorRejectionProps = {
+  submission: SerializableSubmission;
 };
 
-const MySubmissions = ({ user, submissions, formNames }: MySubmissionsProps) => {
+const PriorRejection = ({ submission }: PriorRejectionProps) => {
+  return (
+    <Stack spacing="1" py="2">
+      <HStack>
+        <Tag colorScheme="red" size="sm">
+          Rejected
+        </Tag>
+        <Text fontSize="sm" color="gray.500">
+          {getDateFromObjectId(submission._id)}
+        </Text>
+      </HStack>
+      <Text fontSize="sm">{submission.comment ?? "No comment provided."}</Text>
+    </Stack>
+  );
+};
+
+type FormGroup = {
+  formSlug: string;
+  formName: string;
+  latest: SerializableSubmission;
+  priorRejections: SerializableSubmission[];
+};
+
+type FormGroupCardProps = {
+  group: FormGroup;
+};
+
+const FormGroupCard = ({ group }: FormGroupCardProps) => {
+  const shadow = useColorModeValue("base", "md");
+  const bg = useColorModeValue("white", "gray.800");
+  const latestStatus = group.latest.status ?? SubmissionStatus.UNDER_REVIEW;
+
+  return (
+    <Stack shadow={shadow} bg={bg} rounded="md" p="4" spacing="4">
+      <HStack justifyContent="space-between" alignItems="flex-start">
+        <Box>
+          <Text fontSize="md" fontWeight="bold">
+            {group.formName}
+          </Text>
+          <Text fontSize="sm" color="gray.500">
+            Latest: {getDateFromObjectId(group.latest._id)}
+          </Text>
+        </Box>
+        <Badge colorScheme={STATUS_COLORS[latestStatus]}>{STATUS_LABELS[latestStatus]}</Badge>
+      </HStack>
+
+      {group.latest.comment && (
+        <Box borderLeftWidth="2px" borderColor="gray.500" pl="3">
+          <Text fontSize="sm" color="gray.400">
+            Reviewer Comment
+          </Text>
+          <Text fontSize="sm">{group.latest.comment}</Text>
+        </Box>
+      )}
+
+      {latestStatus === SubmissionStatus.REJECTED && (
+        <Link href={`/a/${group.formSlug}`} passHref legacyBehavior>
+          <Button as="a" size="sm" colorScheme="blue" variant="outline" rightIcon={<HiChevronRight />}>
+            Resubmit
+          </Button>
+        </Link>
+      )}
+
+      {group.priorRejections.length > 0 && (
+        <>
+          <Divider />
+          <Heading size="xs" color="gray.500">
+            Prior Rejections
+          </Heading>
+          {group.priorRejections.map((r) => (
+            <PriorRejection key={r._id} submission={r} />
+          ))}
+        </>
+      )}
+    </Stack>
+  );
+};
+
+type MySubmissionsProps = {
+  user: User;
+  formGroups: FormGroup[];
+  ungroupedSubmissions: SerializableSubmission[];
+};
+
+const MySubmissions = ({ user, formGroups, ungroupedSubmissions }: MySubmissionsProps) => {
+  const hasAny = formGroups.length > 0 || ungroupedSubmissions.length > 0;
+
   return (
     <MainLayout user={user}>
       <Stack spacing="4" maxW="xl" mx="auto">
         <Heading mb="2">My Submissions</Heading>
 
-        {submissions.length === 0 ? (
+        {!hasAny ? (
           <Text color="gray.500">You have not submitted any forms yet.</Text>
         ) : (
-          submissions.map((submission) => (
-            <SubmissionCard
-              key={submission._id}
-              submission={submission}
-              formName={formNames[submission.form_id] ?? submission.form_id}
-            />
-          ))
+          <>
+            {formGroups.map((group) => (
+              <FormGroupCard key={group.formSlug} group={group} />
+            ))}
+            {ungroupedSubmissions.map((submission) => (
+              <SubmissionCard key={submission._id} submission={submission} />
+            ))}
+          </>
         )}
       </Stack>
     </MainLayout>
@@ -118,6 +200,7 @@ export const getServerSideProps = withServerSideSession<MySubmissionsProps>(asyn
 
   const _submissions = await fetchUserSubmissions(user.id);
   const submissions = await _submissions.toArray();
+  const serialized = submissions.map(makeSerializable);
 
   const forms = await Promise.allSettled(FORMS.map((slug) => formium.getFormBySlug(slug)));
   const formNames: { [key: string]: string } = {};
@@ -127,11 +210,43 @@ export const getServerSideProps = withServerSideSession<MySubmissionsProps>(asyn
     }
   });
 
+  // Group submissions by form
+  const byForm: { [formId: string]: SerializableSubmission[] } = {};
+  const ungroupedSubmissions: SerializableSubmission[] = [];
+
+  for (const sub of serialized) {
+    if (FORMS.includes(sub.form_id)) {
+      if (!byForm[sub.form_id]) byForm[sub.form_id] = [];
+      byForm[sub.form_id].push(sub);
+    } else {
+      ungroupedSubmissions.push(sub);
+    }
+  }
+
+  // Build form groups: latest submission + prior rejections
+  const formGroups: FormGroup[] = [];
+  for (const formSlug of FORMS) {
+    const formSubs = byForm[formSlug];
+    if (!formSubs || formSubs.length === 0) continue;
+
+    const latest = formSubs[0]; // Already sorted newest-first by fetchUserSubmissions
+    const priorRejections = formSubs
+      .slice(1)
+      .filter((s) => s.status === SubmissionStatus.REJECTED);
+
+    formGroups.push({
+      formSlug,
+      formName: formNames[formSlug] ?? formSlug,
+      latest,
+      priorRejections,
+    });
+  }
+
   return {
     props: {
       user,
-      submissions: submissions.map(makeSerializable),
-      formNames,
+      formGroups,
+      ungroupedSubmissions,
     },
   };
 }, AuthMode.AUTHENTICATED);


### PR DESCRIPTION
## Summary

Adds a new `/my-submissions` page where authenticated users can view all of their previous form submissions, **grouped by form type** and integrated with the prior rejections feature from #4.

Changes:
- **`helpers/db.ts`**: Added `fetchUserSubmissions()` to query all submissions for a given user, sorted newest-first.
- **`pages/my-submissions.tsx`**: New page that groups submissions by form (Moderator Application, Ban Appeal, Suspension Appeal). Each form group shows the latest submission with its status badge and reviewer comment, a "Prior Rejections" section listing older rejected submissions with their comments (mirroring the admin-side view from #4), and a "Resubmit" button when the latest submission was rejected. Internal review statuses (MARKED_*) are displayed as "Under Review" to users. Submissions from unknown form slugs fall back to a simpler ungrouped card.
- **`components/layouts/MainLayout.tsx`**: Added "My Submissions" nav item to the sidebar.

Sensitive fields like `reviewer_id`, `email`, `user_id`, and `user_tag` are stripped server-side to avoid leaking staff Discord IDs through `__NEXT_DATA__`.

### Updates since last revision

- **View My Answers**: Each form group now includes a collapsible **"View My Answers"** toggle that reveals the user's submitted form data. Field labels are resolved from the Formium form schema (slug → human-readable title); unrecognized fields fall back to showing the raw slug.
- The `data` field is now included in `UserSubmission` and sent to the client (it contains only the user's own answers, not staff data).
- Added `SubmissionAnswers` component that renders known fields (with proper labels from Formium schema) first, then any extra fields.
- Form field name mappings (`fieldNames`) are extracted server-side from `form.schema.fields` and passed per form group.

## Review & Testing Checklist for Human

- [ ] **`data` field now sent to client**: Previously `data` was stripped from page props. It's now included since it contains the user's own answers. **Verify that `data` never contains anything sensitive beyond the user's own input** (e.g., internal metadata injected server-side).
- [ ] **`data` cast to `Record<string, string>`**: The submission `data` field is generic (`T = any`). If any form fields store non-string values (objects, arrays, numbers), they will render via `.toString()` which may look wrong. Check whether any forms have non-string field types.
- [ ] **Formium schema field extraction**: Field names are resolved via `field as { slug: string; title?: string }`. If the Formium schema structure differs from this assumption, fields will silently fall back to showing raw slugs instead of titles. Verify field labels render correctly for each form type.
- [ ] **Grouping logic depends on sort order**: `formSubs[0]` is assumed to be the newest submission because `fetchUserSubmissions` sorts by `{ _id: -1 }`. Verify this holds — if the sort ever changes, the "latest" card would show the wrong submission.
- [ ] **No pagination on `fetchUserSubmissions`**: The DB query has no `.limit()`. If a user has a very large number of submissions, this will load them all into memory. Consider whether pagination or a reasonable limit is needed.

**Recommended test plan**: Log in via Discord → navigate to "My Submissions" in the sidebar → verify each form group shows the latest submission with correct status badge → click "View My Answers" and confirm form answers display with proper field labels → for a form with prior rejections, verify the "Prior Rejections" section lists them with comments → click "Resubmit" on a rejected form and confirm it navigates to `/a/{form-slug}` → log in as a user with no submissions and confirm the empty state message.

### Notes
- The `FORMS` slug list is duplicated from `dashboard.tsx`. Could be extracted to a shared constant in a follow-up.
- Submission dates are derived from the MongoDB ObjectId timestamp, which is the insertion time — this should match the actual submission time.
- Tested locally with mock data only (screenshots in [PR comment](https://github.com/poketwo/forms.poketwo.net/pull/5#issuecomment-4180620556)). The answer viewing feature has not been tested against real Formium schema data.
- Vercel preview deploy fails as expected (env vars not configured on Vercel for this branch).

Link to Devin session: https://app.devin.ai/sessions/26650785bd61448cb0b5176d552b3997
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/forms.poketwo.net/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
