### PR TITLE
fix(session): keep member data out of the session cookie

### DIFF
--- a/helpers/session.ts
+++ b/helpers/session.ts
@@ -1,4 +1,3 @@
-import { TokenRequestResult } from "discord-oauth2";
 import { IronSession, getIronSession } from "iron-session";
 import {
   GetServerSidePropsContext,
@@ -27,7 +26,6 @@ type SessionVars = {
   error?: string;
   next?: string;
   id?: string;
-  token?: TokenRequestResult;
 };
 
 export type NextIronRequest = NextApiRequest & { session: IronSession<SessionVars> };
@@ -65,6 +63,17 @@ const addMemberInfo = async (session: IronSession<SessionVars>) => {
   session.poketwoMember = poketwoMember;
 
   return { user, member, poketwoMember };
+};
+
+// Member data is refetched on every request, and staff members have large role
+// lists that can push the session cookie past the browser size limit.
+export const saveSession = async (session: IronSession<SessionVars>) => {
+  const { member, poketwoMember } = session;
+  session.member = undefined;
+  session.poketwoMember = undefined;
+  await session.save();
+  session.member = member;
+  session.poketwoMember = poketwoMember;
 };
 
 const handleRequest = async (user: User | undefined, mode: AuthMode) => {

--- a/pages/api/callback.ts
+++ b/pages/api/callback.ts
@@ -2,9 +2,8 @@ import crypto from "crypto";
 import { NextApiResponse } from "next";
 import absoluteUrl from "next-absolute-url";
 
-import { fetchMember } from "~helpers/db";
 import oauth from "~helpers/oauth";
-import { AuthMode, NextIronRequest, withSession } from "~helpers/session";
+import { AuthMode, NextIronRequest, saveSession, withSession } from "~helpers/session";
 
 const handler = async (req: NextIronRequest, res: NextApiResponse) => {
   const id = req.session.id;
@@ -22,15 +21,12 @@ const handler = async (req: NextIronRequest, res: NextApiResponse) => {
     redirectUri: `${origin}/api/callback`,
   });
   const user = await oauth.getUser(token.access_token);
-  const member = await fetchMember(user.id);
 
   const next = req.session.next;
   req.session.next = undefined;
 
-  req.session.token = token;
   req.session.user = <any>user;
-  req.session.member = member;
-  await req.session.save();
+  await saveSession(req.session);
 
   res.redirect(next ?? "/");
 };

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -3,7 +3,7 @@ import { NextApiResponse } from "next";
 import absoluteUrl from "next-absolute-url";
 
 import oauth from "~helpers/oauth";
-import { AuthMode, NextIronRequest, withSession } from "~helpers/session";
+import { AuthMode, NextIronRequest, saveSession, withSession } from "~helpers/session";
 
 const handler = async (req: NextIronRequest, res: NextApiResponse) => {
   let id = req.session.id;
@@ -11,7 +11,7 @@ const handler = async (req: NextIronRequest, res: NextApiResponse) => {
   if (!id) {
     id = crypto.randomBytes(16).toString("hex");
     req.session.id = id;
-    await req.session.save();
+    await saveSession(req.session);
   }
 
   const { origin } = absoluteUrl(req);


### PR DESCRIPTION
## Summary
Login fails for members with large `member` documents (staff, with long role lists). The production pod logs show `/api/callback` throwing:

```
Error: iron-session: Cookie length is too big (45951 bytes), browsers will refuse it.
    at Object.save (iron-session/dist/index.js:183)
    at async l (.next/server/pages/api/callback.js)
```

`save()` throws → callback 500s → no session cookie is set → the user can never reach any authenticated page (e.g. senior moderators being unable to open `ban-appeal` / `moderator-application` submissions).

Cause: `callback.ts` persisted `member` (plus `poketwoMember`, set by `addMemberInfo`, and an unused `token`) into the encrypted cookie. None of that needs persisting — `withSession` / `withServerSideSession` refetch member data from Mongo on every request (60s `NodeCache`).

Fix: a `saveSession` helper that strips the refetched fields before writing the cookie, keeping the persisted payload to `user`/`id`/`next`:

```ts
export const saveSession = async (session) => {
  const { member, poketwoMember } = session;
  session.member = undefined;
  session.poketwoMember = undefined;
  await session.save();
  session.member = member;          // still available to the current request
  session.poketwoMember = poketwoMember;
};
```

`callback.ts` and `login.ts` use it instead of `session.save()`; the unused `token` field is dropped from `SessionVars`.

Verified with `npx tsc --noEmit` and `npx next lint` (only pre-existing warnings).


Link to Devin session: https://app.devin.ai/sessions/f4013bbac04047b48f3dcbd0eda27a6d
Requested by: @VarMonke