### PR TITLE
feat(permissions): let senior mods read full ban appeals

### DIFF
--- a/helpers/permissions.ts
+++ b/helpers/permissions.ts
@@ -29,3 +29,9 @@ export const hasFullAccess = (member: Member, formId: string) => {
   const fullRoles = fullAccessRoles[formId] ?? [];
   return roles.some((role) => fullRoles.includes(role));
 };
+
+// Forms whose first page holds demographic details, hidden from restricted roles.
+const redactedForms = ["moderator-application"];
+
+export const hasFullContentAccess = (member: Member, formId: string) =>
+  !redactedForms.includes(formId) || hasFullAccess(member, formId);

--- a/pages/a/[formId]/submissions/[submissionId].tsx
+++ b/pages/a/[formId]/submissions/[submissionId].tsx
@@ -42,7 +42,7 @@ import SubmissionsLayout from "~components/layouts/SubmissionsLayout";
 import { fetchSubmission, fetchSubmissions, fetchUserFormSubmissions } from "~helpers/db";
 import { formium } from "~helpers/formium";
 import { getFirstPageFieldSlugs } from "~helpers/form";
-import { hasFullAccess, permittedToViewForm } from "~helpers/permissions";
+import { hasFullAccess, hasFullContentAccess, permittedToViewForm } from "~helpers/permissions";
 import { AuthMode, withServerSideSession } from "~helpers/session";
 import {
   SerializableSubmission,
@@ -370,9 +370,10 @@ type SubmissionPageProps = {
   submission: SerializableSubmission;
   userSubmissions: SerializableSubmission[];
   fullAccess: boolean;
+  fullContent: boolean;
 };
 
-const SubmissionPage = ({ user, form, submissions, submission, userSubmissions, fullAccess }: SubmissionPageProps) => {
+const SubmissionPage = ({ user, form, submissions, submission, userSubmissions, fullAccess, fullContent }: SubmissionPageProps) => {
   const [subs, setSubs] = useState(submissions);
   const [sub, setSub] = useState(submission);
   const [statusWithComment, setStatusWithComment] = useState<SubmissionStatus | undefined>();
@@ -424,7 +425,7 @@ const SubmissionPage = ({ user, form, submissions, submission, userSubmissions, 
           <SubmissionHeader submission={sub} onSetStatus={handleSetStatus} canFlag={!fullAccess} fullAccess={fullAccess} />
         </Box>
         <Box flex="1" overflow="auto" p="6" zIndex={0}>
-          <SubmissionContent key={form.id} form={form} submission={sub} hideFirstPage={!fullAccess} />
+          <SubmissionContent key={form.id} form={form} submission={sub} hideFirstPage={!fullContent} />
 
           {userSubmissions.length > 0 && (
             <Stack spacing="2" mt="6">
@@ -494,9 +495,10 @@ export const getServerSideProps = withServerSideSession<SubmissionPageProps, Sub
       .map(makeSerializable);
 
     const fullAccess = hasFullAccess(member, formId);
+    const fullContent = hasFullContentAccess(member, formId);
     const serializedSubmission = makeSerializable(submission);
 
-    if (!fullAccess) {
+    if (!fullContent) {
       const firstPageSlugs = getFirstPageFieldSlugs(form);
       const filteredData = Object.fromEntries(
         Object.entries(serializedSubmission.data).filter(
@@ -515,6 +517,7 @@ export const getServerSideProps = withServerSideSession<SubmissionPageProps, Sub
         submission: serializedSubmission,
         userSubmissions,
         fullAccess,
+        fullContent,
       },
     };
   },


### PR DESCRIPTION
## Summary
Content redaction was tied to `hasFullAccess`, so senior moderators lost the first form page on *every* restricted form. Redaction is now form-specific, keeping review actions untouched:

```ts
const redactedForms = ["moderator-application"];

export const hasFullContentAccess = (member, formId) =>
  !redactedForms.includes(formId) || hasFullAccess(member, formId);
```

The submission page derives them separately — `fullAccess` still gates accept/reject (and the API route's `FLAG_STATUSES` check is unchanged), while `fullContent` gates the server-side first-page stripping and `hideFirstPage`.

Net effect for a senior mod: `ban-appeal` is fully readable but flag-only; `moderator-application` is unchanged (page 1 redacted, flag-only).


Link to Devin session: https://app.devin.ai/sessions/f4013bbac04047b48f3dcbd0eda27a6d
Requested by: @VarMonke